### PR TITLE
Fix ffmpeg seek command

### DIFF
--- a/ChapterApi/Api/ExtractApiEndpoint.cs
+++ b/ChapterApi/Api/ExtractApiEndpoint.cs
@@ -32,6 +32,7 @@ using MediaBrowser.Model.Services;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Security.Cryptography;
 using System.Text;
@@ -284,8 +285,8 @@ namespace ChapterApi
 
             command_params.Add("-accurate_seek");
             command_params.Add("-i \"" + media_path + "\"");
-            command_params.Add(string.Format("-ss {0}", ts_start.TotalSeconds));
-            command_params.Add(string.Format("-t {0}", ts_duration.TotalSeconds));
+            command_params.Add(string.Format("-ss {0}", ts_start.TotalSeconds.ToString(CultureInfo.CreateSpecificCulture("en-US"))));
+            command_params.Add(string.Format("-t {0}", ts_duration.TotalSeconds.ToString(CultureInfo.CreateSpecificCulture("en-US"))));
             command_params.Add("-ac 1");
             command_params.Add("-acodec pcm_s16le");
             command_params.Add("-ar 44100");
@@ -346,8 +347,8 @@ namespace ChapterApi
 
             command_params.Add("-accurate_seek");
             command_params.Add("-i \"" + media_path + "\"");
-            command_params.Add(string.Format("-ss {0}", ts_start.TotalSeconds));
-            command_params.Add(string.Format("-t {0}", ts_duration.TotalSeconds));
+            command_params.Add(string.Format("-ss {0}", ts_start.TotalSeconds.ToString(CultureInfo.CreateSpecificCulture("en-US"))));
+            command_params.Add(string.Format("-t {0}", ts_duration.TotalSeconds.ToString(CultureInfo.CreateSpecificCulture("en-US"))));
             command_params.Add("-ac 1");
             command_params.Add("-acodec pcm_s16le");
             command_params.Add("-ar 44100");


### PR DESCRIPTION
ffmpeg doesn't like "commas" as a decimal separator that is used in many european countries and therefor is set as the default separator depending on the OS regional settings.